### PR TITLE
Remove class_name for node registration

### DIFF
--- a/addons/SIsilicon.3d.text/label_3d.gd
+++ b/addons/SIsilicon.3d.text/label_3d.gd
@@ -1,6 +1,5 @@
 tool
 extends Spatial
-class_name Label3D
 
 export(String, MULTILINE) var text = "Text" setget set_text
 export(float) var text_scale = 0.01 setget set_text_scale


### PR DESCRIPTION
Label3D was apparing two times in the "Add Node" dialog:
![image](https://user-images.githubusercontent.com/28286961/95908379-4e52ae00-0d9d-11eb-9f5f-5e82fee8b92a.png)
