### PR TITLE
Fix emission initialization

### DIFF
--- a/addons/SIsilicon.3d.text/label_3d.gd
+++ b/addons/SIsilicon.3d.text/label_3d.gd
@@ -47,8 +47,10 @@ func _ready():
 	set_extrude(extrude)
 	
 	set_color(color)
+	set_emission_color(emission_color)
 	set_metallic(metallic)
 	set_roughness(roughness)
+	set_emission(emission)
 	
 	set_max_steps(max_steps)
 	set_step_size(step_size)


### PR DESCRIPTION
I forgot to set the emission values on _ready, which made them only work after tweaking them.